### PR TITLE
New sprintf method

### DIFF
--- a/src/Caster.php
+++ b/src/Caster.php
@@ -644,6 +644,22 @@ class Caster implements CasterInterface
         );
     }
 
+    public function sprintf(string $format, mixed ...$values): string
+    {
+        /** @var array<float|int|string> $valuesVariant */
+        $valuesVariant = [];
+
+        foreach ($values as $k => $v) {
+            if (false === is_float($v) && false === is_int($v)) {
+                $v = $this->cast($v);
+            }
+
+            $valuesVariant[$k] = $v;
+        }
+
+        return sprintf($format, ...$valuesVariant);
+    }
+
     public function withArraySampleSize(UnsignedInteger $arraySampleSize): static
     {
         $clone = clone $this;

--- a/src/Contract/CasterInterface.php
+++ b/src/Contract/CasterInterface.php
@@ -105,7 +105,8 @@ interface CasterInterface extends ImmutableObjectInterface
      * Must have behavior very similar to that of the PHP core function `sprintf`. However, all values contained in the
      * $values argument, which are NOT float or int, must be wrapped using the `cast` method in the implementing class.
      *
-     * Unlike the PHP core function `sprintf`, however, you may pass any data type – including objects and arrays – in
+     * Unlike the PHP core function `sprintf`, however, you may pass any data type – including null, booleans, arrays,
+     * and objects (even objects, which do not implement the Stringable interface or has the `__toString` method) – in
      * this method, as these will be converted to their string represenations via the `cast` method.
      *
      * Method logic must NOT handle things like argnum, flags, width or precision, e.g. "%1$s", "%04s", "%2.3s".

--- a/src/Contract/CasterInterface.php
+++ b/src/Contract/CasterInterface.php
@@ -102,6 +102,23 @@ interface CasterInterface extends ImmutableObjectInterface
     public function quoteAndEscape(string $str): string;
 
     /**
+     * Must have behavior very similar to that of the PHP core function `sprintf`. However, all values contained in the
+     * $values argument, which are NOT float or int, must be wrapped using the `cast` method in the implementing class.
+     *
+     * Unlike the PHP core function `sprint`, however, you may pass any data type – including objects and arrays – in
+     * this method, as these will be converted to their string represenations via the `cast` method.
+     *
+     * Method logic must NOT handle things like argnum, flags, width or precision, e.g. "%1$s", "%04s", "%2.3s".
+     * Instead, format the values beforehand, pass them as strings, and use a simple "%s". The result of
+     * "$this->cast('%04s', 'a')" will be `0"a"` (2x double quote takes up two of the characters) and NOT `"0a"` or
+     * `"000a"`. Supporting these flags to make outputs like `"000a"`, would require a lot of reimplementing the
+     * internals of the `sprintf` function, which we do not wish to do here. The use cases are very limited.
+     *
+     * @see https://www.php.net/manual/en/function.sprintf.php
+     */
+    public function sprintf(string $format, mixed ...$values): string;
+
+    /**
      * Must set the maximum number of elements to be displayed in an array on a clone of the current instance.
      * Must return said clone.
      */

--- a/src/Contract/CasterInterface.php
+++ b/src/Contract/CasterInterface.php
@@ -105,7 +105,7 @@ interface CasterInterface extends ImmutableObjectInterface
      * Must have behavior very similar to that of the PHP core function `sprintf`. However, all values contained in the
      * $values argument, which are NOT float or int, must be wrapped using the `cast` method in the implementing class.
      *
-     * Unlike the PHP core function `sprint`, however, you may pass any data type – including objects and arrays – in
+     * Unlike the PHP core function `sprintf`, however, you may pass any data type – including objects and arrays – in
      * this method, as these will be converted to their string represenations via the `cast` method.
      *
      * Method logic must NOT handle things like argnum, flags, width or precision, e.g. "%1$s", "%04s", "%2.3s".

--- a/tests/tests/Test/Unit/CasterTest.php
+++ b/tests/tests/Test/Unit/CasterTest.php
@@ -1788,6 +1788,67 @@ class CasterTest extends TestCase
         $this->assertSame('"\\\\foo\\""', Caster::create()->quoteAndEscape('\\foo"'));
     }
 
+    /**
+     * @param array<mixed> $values
+     *
+     * @dataProvider dataProviderTestSprintfWorks
+     */
+    public function testSprintfWorks(string $expected, string $format, array $values): void
+    {
+        $this->assertSame($expected, Caster::getInstance()->sprintf($format, ...$values));
+    }
+
+    /**
+     * @return array<array{string, string, array<mixed>}>
+     */
+    public function dataProviderTestSprintfWorks(): array
+    {
+        return [
+            [
+                '"foo"',
+                '%s',
+                ['foo'],
+            ],
+            [
+                '42 43 3.140000',
+                '%s %d %f',
+                [42, 43, 3.14],
+            ],
+            [
+                '"foo" "bar" "baz"',
+                '%s %s %s',
+                ['foo', 'bar', 'baz'],
+            ],
+            [
+                '"foo" "foo"',
+                '%s %1$s',
+                ['foo'],
+            ],
+            [
+                /**
+                 * Perhaps this output may seem strange, but it is covered in the CasterInterface at the `sprintf`
+                 * method. You might have expected the output to be `"000a"`, alas, we have opted out of supporting this
+                 * behavior due to complexity and limited use cases.
+                 *
+                 * 2x double quotes take up 2 characters, which is why it is not `000"a".
+                 */
+                '0"a"',
+                '%04s',
+                ['a'],
+            ],
+            [
+                '[0 => "foo"]',
+                '%s',
+                [['foo']],
+            ],
+            [
+                '\\stdClass',
+                '%s',
+                [new stdClass()],
+            ],
+        ];
+    }
+
     public function testWithArraySampleSizeWorks(): void
     {
         $casterA = Caster::create();


### PR DESCRIPTION
To combat redundancy, calling the `cast` method repeatedly during the specification of the $values arugment.