### PR TITLE
Implemented formatters for several Reflection API classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
         }
     ],
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "files": [

--- a/src/Assertion.php
+++ b/src/Assertion.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster;
+
+use Eboreum\Caster\Exception\AssertionException;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * A minimalist class for asserting values are as expected. Inspired by other libraries. However, we do not want a hard
+ * dependency to these libraries from this library, so here is merely implemented the bare minimum we need.
+ *
+ * @see https://packagist.org/packages/webmozart/assert
+ * @see https://packagist.org/packages/beberlei/assert
+ */
+final class Assertion
+{
+    /**
+     * @throws AssertionException
+     */
+    public static function assertIsString(mixed $value, ?string $message = null): void
+    {
+        if (false === is_string($value)) {
+            throw new AssertionException(sprintf(
+                'Expects argument $value = %s to be a string, but it is not%s',
+                Caster::getInternalInstance()->castTyped($value),
+                ($message ? ': ' . $message : ''),
+            ));
+        }
+    }
+}

--- a/src/Caster.php
+++ b/src/Caster.php
@@ -31,9 +31,18 @@ use Eboreum\Caster\Formatter\DefaultObjectFormatter;
 use Eboreum\Caster\Formatter\DefaultResourceFormatter;
 use Eboreum\Caster\Formatter\DefaultStringFormatter;
 use Eboreum\Caster\Formatter\Object_\DebugIdentifierAttributeInterfaceFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionClassFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionMethodFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionPropertyFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionTypeFormatter;
 use Eboreum\Caster\Formatter\Object_\TextuallyIdentifiableInterfaceFormatter;
+use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionObject;
+use ReflectionProperty;
+use ReflectionType;
 use Throwable;
 
 use function addcslashes;
@@ -506,6 +515,100 @@ class Caster implements CasterInterface
         }
 
         return $return;
+    }
+
+    /**
+     * Convenience method for casting a ReflectionAttribute to a string, rendering full class namespace and potential
+     * arguments.
+     *
+     * @see https://www.php.net/manual/en/class.reflectionattribute.php
+     *
+     * @param ReflectionAttribute<object> $reflectionAttribute
+     */
+    public function castReflectionAttributeToString(ReflectionAttribute $reflectionAttribute): string
+    {
+        $formatter = new ReflectionAttributeFormatter();
+        $formatter = $formatter->withIsWrappingInClassName(false);
+        $formatted = $formatter->format($this, $reflectionAttribute);
+
+        Assertion::assertIsString($formatted);
+        assert(is_string($formatted));
+
+        return $formatted;
+    }
+
+    /**
+     * Convenience method for casting a ReflectionClass to a string, rendering full class namespace and an optional type
+     * prefix (class, enum, interface, trait).
+     *
+     * @see https://www.php.net/manual/en/class.reflectionclass.php
+     *
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    public function castReflectionClassToString(ReflectionClass $reflectionClass): string
+    {
+        $formatter = new ReflectionClassFormatter();
+        $formatter = $formatter->withIsWrappingInClassName(false);
+        $formatted = $formatter->format($this, $reflectionClass);
+
+        Assertion::assertIsString($formatted);
+        assert(is_string($formatted));
+
+        return $formatted;
+    }
+
+    /**
+     * Convenience method for casting a ReflectionMethod to a string, rendering full class name space, method name, and
+     * all of the method's parameters.
+     *
+     * @see https://www.php.net/manual/en/class.reflectionmethod.php
+     */
+    public function castReflectionMethodToString(ReflectionMethod $reflectionMethod): string
+    {
+        $formatter = new ReflectionMethodFormatter();
+        $formatter = $formatter->withIsWrappingInClassName(false);
+        $formatted = $formatter->format($this, $reflectionMethod);
+
+        Assertion::assertIsString($formatted);
+        assert(is_string($formatted));
+
+        return $formatted;
+    }
+
+    /**
+     * Convenience method for casting a ReflectionProperty to a string, rendering full class name space, property name,
+     * and optionally the property's type.
+     *
+     * @see https://www.php.net/manual/en/class.reflectionproperty.php
+     */
+    public function castReflectionPropertyToString(ReflectionProperty $reflectionProperty): string
+    {
+        $formatter = new ReflectionPropertyFormatter();
+        $formatter = $formatter->withIsWrappingInClassName(false);
+        $formatted = $formatter->format($this, $reflectionProperty);
+
+        Assertion::assertIsString($formatted);
+        assert(is_string($formatted));
+
+        return $formatted;
+    }
+
+    /**
+     * Convenience method for casting a ReflectionType to a string, normalizing all classish (class, enum, interface,
+     * trait) references.
+     *
+     * @see https://www.php.net/manual/en/class.reflectiontype.php
+     */
+    public function castReflectionTypeToString(ReflectionType $reflectionType): string
+    {
+        $formatter = new ReflectionTypeFormatter();
+        $formatter = $formatter->withIsWrappingInClassName(false);
+        $formatted = $formatter->format($this, $reflectionType);
+
+        Assertion::assertIsString($formatted);
+        assert(is_string($formatted));
+
+        return $formatted;
     }
 
     /**

--- a/src/Exception/AssertionException.php
+++ b/src/Exception/AssertionException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Exception;
+
+use RuntimeException;
+
+/**
+ * For use with assertions.
+ */
+class AssertionException extends RuntimeException
+{
+}

--- a/src/Formatter/Object_/ReflectionAttributeFormatter.php
+++ b/src/Formatter/Object_/ReflectionAttributeFormatter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use ReflectionAttribute;
+use ReflectionClass;
+
+use function assert;
+use function implode;
+use function sprintf;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionAttribute.
+ *
+ * @see https://www.php.net/manual/en/class.reflectionattribute.php
+ */
+class ReflectionAttributeFormatter extends AbstractObjectFormatter
+{
+    protected bool $isWrappingInClassName = true;
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionAttribute); // Make phpstan happy
+
+        $str = '';
+
+        if ($caster->isPrependingType()) {
+            $str = '(attribute) ';
+        }
+
+        $str .= Caster::makeNormalizedClassName(new ReflectionClass($object->getName()));
+
+        /** @var array<string> $argumentsAsStrings */
+        $argumentsAsStrings = [];
+
+        foreach ($object->getArguments() as $key => $value) {
+            $argumentsAsStrings[] = sprintf(
+                '%s: %s',
+                $key,
+                $caster->cast($value),
+            );
+        }
+
+        if ($argumentsAsStrings) {
+            $str .= sprintf(' (%s)', implode(', ', $argumentsAsStrings));
+        }
+
+        if ($this->isWrappingInClassName()) {
+            $str = sprintf(
+                '%s (%s)',
+                Caster::makeNormalizedClassName(new ReflectionClass($object)),
+                $str,
+            );
+        }
+
+        return $str;
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionAttribute);
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+}

--- a/src/Formatter/Object_/ReflectionClassFormatter.php
+++ b/src/Formatter/Object_/ReflectionClassFormatter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use ReflectionClass;
+
+use function assert;
+use function sprintf;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionClass.
+ *
+ * @see https://www.php.net/manual/en/class.reflectionclass.php
+ */
+class ReflectionClassFormatter extends AbstractObjectFormatter
+{
+    protected bool $isWrappingInClassName = true;
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionClass); // Make phpstan happy
+
+        $str = '';
+
+        if ($caster->isPrependingType()) {
+            if ($object->isEnum()) {
+                $str = '(enum) ';
+            } elseif ($object->isInterface()) {
+                $str = '(interface) ';
+            } elseif ($object->isTrait()) {
+                $str = '(trait) ';
+            } else {
+                $str = '(class) ';
+            }
+        }
+
+        $str .= Caster::makeNormalizedClassName($object);
+
+        if ($this->isWrappingInClassName()) {
+            $str = sprintf(
+                '%s (%s)',
+                Caster::makeNormalizedClassName(new ReflectionClass($object)),
+                $str,
+            );
+        }
+
+        return $str;
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionClass);
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+}

--- a/src/Formatter/Object_/ReflectionMethodFormatter.php
+++ b/src/Formatter/Object_/ReflectionMethodFormatter.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use ReflectionClass;
+use ReflectionMethod;
+
+use function assert;
+use function implode;
+use function sprintf;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionMethod.
+ *
+ * @see https://www.php.net/manual/en/class.reflectionmethod.php
+ */
+class ReflectionMethodFormatter extends AbstractObjectFormatter
+{
+    protected bool $isRenderingParameters = true;
+
+    protected bool $isRenderingReturnType = true;
+
+    protected bool $isWrappingInClassName = true;
+
+    protected ReflectionParameterFormatter $reflectionParameterFormatter;
+
+    protected ReflectionTypeFormatter $reflectionTypeFormatter;
+
+    public function __construct()
+    {
+        $this->reflectionParameterFormatter = (new ReflectionParameterFormatter())->withIsWrappingInClassName(false);
+        $this->reflectionTypeFormatter = (new ReflectionTypeFormatter())->withIsWrappingInClassName(false);
+    }
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionMethod); // Make phpstan happy
+
+        $str = sprintf(
+            '%s%s%s',
+            Caster::makeNormalizedClassName($object->getDeclaringClass()),
+            ($object->isStatic() ? '::' : '->'),
+            $object->getName(),
+        );
+
+        if ($this->isRenderingParameters()) {
+            /** @var array<string> $parametersAsStrings */
+            $parametersAsStrings = [];
+
+            foreach ($object->getParameters() as $reflectionParameter) {
+                $parametersAsStrings[] = $this
+                    ->getReflectionParameterFormatter()
+                    ->format($caster, $reflectionParameter);
+            }
+
+            $str .= '(' . implode(', ', $parametersAsStrings) . ')';
+        }
+
+        if ($this->isRenderingReturnType() && $object->getReturnType()) {
+            $str .= ': ' . $this->getReflectionTypeFormatter()->format($caster, $object->getReturnType());
+        }
+
+        if ($this->isWrappingInClassName()) {
+            $str = sprintf(
+                '%s (%s)',
+                Caster::makeNormalizedClassName(new ReflectionClass($object)),
+                $str,
+            );
+        }
+
+        return $str;
+    }
+
+    public function getReflectionParameterFormatter(): ReflectionParameterFormatter
+    {
+        return $this->reflectionParameterFormatter;
+    }
+
+    public function getReflectionTypeFormatter(): ReflectionTypeFormatter
+    {
+        return $this->reflectionTypeFormatter;
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionMethod);
+    }
+
+    public function isRenderingParameters(): bool
+    {
+        return $this->isRenderingParameters;
+    }
+
+    public function isRenderingReturnType(): bool
+    {
+        return $this->isRenderingReturnType;
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsRenderingParameters(bool $isRenderingParameters): self
+    {
+        $clone = clone $this;
+        $clone->isRenderingParameters = $isRenderingParameters;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsRenderingReturnType(bool $isRenderingReturnType): self
+    {
+        $clone = clone $this;
+        $clone->isRenderingReturnType = $isRenderingReturnType;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withReflectionParameterFormatter(ReflectionParameterFormatter $reflectionParameterFormatter): self
+    {
+        $clone = clone $this;
+        $clone->reflectionParameterFormatter = $reflectionParameterFormatter;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withReflectionTypeFormatter(ReflectionTypeFormatter $reflectionTypeFormatter): self
+    {
+        $clone = clone $this;
+        $clone->reflectionTypeFormatter = $reflectionTypeFormatter;
+
+        return $clone;
+    }
+}

--- a/src/Formatter/Object_/ReflectionParameterFormatter.php
+++ b/src/Formatter/Object_/ReflectionParameterFormatter.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use Eboreum\Caster\Exception\RuntimeException;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use Throwable;
+
+use function array_key_exists;
+use function assert;
+use function escapeshellarg;
+use function implode;
+use function is_string;
+use function preg_match;
+use function sprintf;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionParameter.
+ *
+ * @see https://www.php.net/manual/en/class.reflectionparameter.php
+ */
+class ReflectionParameterFormatter extends AbstractObjectFormatter
+{
+    public static function getDefaultValueConstantRegex(): string
+    {
+        return sprintf(
+            implode('', [
+                '/',
+                '^',
+                '(',
+                    '(',
+                        '?<globalName>(%s)',
+                    ')',
+                    '|',
+                    '(',
+                        '?<namespacedName>(',
+                            '%1$s(',
+                                '\\\\%1$s',
+                            ')*',
+                            '\\\\%1$s',
+                        ')',
+                    ')',
+                    '|',
+                    '(',
+                        '(',
+                            '?<scope>(parent|self)',
+                        ')',
+                        '::',
+                        '(',
+                            '?<scopedName>(%1$s)',
+                        ')',
+                    ')',
+                    '|',
+                    '(',
+                        '\\\\?',
+                        '(',
+                            '?<className>(%1$s(\\\\%1$s)*)',
+                        ')',
+                        '::',
+                        '(',
+                            '?<classConstantName>(%1$s)',
+                        ')',
+                    ')',
+                ')',
+                '$',
+                '/',
+            ]),
+            self::getPHPClassNameRegexInner(),
+        );
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.variables.basics.php
+     */
+    public static function getPHPClassNameRegexInner(): string
+    {
+        return '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*';
+    }
+
+    protected bool $isRenderingTypes = true;
+
+    protected bool $isWrappingInClassName = true;
+
+    protected ReflectionTypeFormatter $reflectionTypeFormatter;
+
+    public function __construct()
+    {
+        $this->reflectionTypeFormatter = (new ReflectionTypeFormatter())->withIsWrappingInClassName(false);
+    }
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionParameter); // Make phpstan happy
+
+        $str = '';
+
+        if ($this->isRenderingTypes() && $object->getType()) {
+            $str = $this->getReflectionTypeFormatter()->format($caster, $object->getType()) . ' ';
+
+            if ($object->isVariadic()) {
+                $str .= '...';
+            }
+        }
+
+        $str .= '$' . $object->getName();
+
+        if ($object->isDefaultValueAvailable()) {
+            $str .= ' = ' . $this->formatDefaultValue($caster, $object);
+        }
+
+        if ($this->isWrappingInClassName()) {
+            $str = sprintf(
+                '%s (%s)',
+                Caster::makeNormalizedClassName(new ReflectionClass($object)),
+                $str,
+            );
+        }
+
+        return $str;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function formatDefaultValue(CasterInterface $caster, ReflectionParameter $reflectionParameter): string
+    {
+        try {
+            if (false === $reflectionParameter->isDefaultValueAvailable()) {
+                throw new RuntimeException(sprintf(
+                    'Parameter $%s does not have a default value',
+                    $reflectionParameter->getName(),
+                ));
+            }
+
+            /** @var string|null $defaultValueConstantName */
+            $defaultValueConstantName = $reflectionParameter->getDefaultValueConstantName();
+
+            if ($reflectionParameter->isDefaultValueConstant() && is_string($defaultValueConstantName)) {
+                preg_match(
+                    self::getDefaultValueConstantRegex(),
+                    $defaultValueConstantName,
+                    $match,
+                );
+
+                if (!$match) {
+                    throw new RuntimeException(sprintf(
+                        implode('', [
+                            'Expects default value of parameter $%s - a constant - to match regular expression %s, but',
+                            ' it does not. Found: %s',
+                        ]),
+                        $reflectionParameter->getName(),
+                        escapeshellarg(self::getDefaultValueConstantRegex()),
+                        Caster::getInternalInstance()->castTyped($defaultValueConstantName),
+                    ));
+                }
+
+                foreach (['globalName', 'namespacedName'] as $key) {
+                    if ($match[$key] ?: false) {
+                        return '\\' . $match[$key];
+                    }
+                }
+
+                if (
+                    array_key_exists('scopedName', $match)
+                    && '' !== $match['scopedName']
+                    && array_key_exists('scope', $match)
+                    && '' !== $match['scope']
+                ) {
+                    return sprintf(
+                        '%s::%s',
+                        $match['scope'],
+                        $match['scopedName'],
+                    );
+                }
+
+                if (
+                    array_key_exists('className', $match)
+                    && '' !== $match['className']
+                    && array_key_exists('classConstantName', $match)
+                    && '' !== $match['classConstantName']
+                ) {
+                    return sprintf(
+                        '\\%s::%s',
+                        $match['className'],
+                        $match['classConstantName'],
+                    );
+                }
+            }
+
+            return $caster->cast($reflectionParameter->getDefaultValue());
+        } catch (Throwable $t) {
+            $functionText = '';
+
+            if ($reflectionParameter->getDeclaringClass()) {
+                $isStatic = false;
+
+                if ($reflectionParameter->getDeclaringFunction() instanceof ReflectionMethod) {
+                    $isStatic = $reflectionParameter->getDeclaringFunction()->isStatic();
+                }
+
+                $functionText = sprintf(
+                    'method %s%s%s',
+                    Caster::makeNormalizedClassName($reflectionParameter->getDeclaringClass()),
+                    ($isStatic ? '::' : '->'),
+                    $reflectionParameter->getDeclaringFunction()->getName(),
+                );
+            } else {
+                $functionText = sprintf(
+                    'function \\%s',
+                    $reflectionParameter->getDeclaringFunction()->getName(),
+                );
+            }
+
+            throw new RuntimeException(
+                sprintf(
+                    implode('', [
+                        'A problem was encountered for argument $reflectionParameter, having the parameter name $%s',
+                        ' in %s',
+                    ]),
+                    $reflectionParameter->getName(),
+                    $functionText,
+                ),
+                0,
+                $t,
+            );
+        }
+    }
+
+    public function getReflectionTypeFormatter(): ReflectionTypeFormatter
+    {
+        return $this->reflectionTypeFormatter;
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionParameter);
+    }
+
+    public function isRenderingTypes(): bool
+    {
+        return $this->isRenderingTypes;
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsRenderingTypes(bool $isRenderingTypes): self
+    {
+        $clone = clone $this;
+        $clone->isRenderingTypes = $isRenderingTypes;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withReflectionTypeFormatter(ReflectionTypeFormatter $reflectionTypeFormatter): self
+    {
+        $clone = clone $this;
+        $clone->reflectionTypeFormatter = $reflectionTypeFormatter;
+
+        return $clone;
+    }
+}

--- a/src/Formatter/Object_/ReflectionPropertyFormatter.php
+++ b/src/Formatter/Object_/ReflectionPropertyFormatter.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use ReflectionClass;
+use ReflectionProperty;
+
+use function assert;
+use function sprintf;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionProperty.
+ *
+ * @see https://www.php.net/manual/en/class.reflectionproperty.php
+ */
+class ReflectionPropertyFormatter extends AbstractObjectFormatter
+{
+    protected bool $isRenderingParameters = true;
+
+    protected bool $isWrappingInClassName = true;
+
+    protected ReflectionTypeFormatter $reflectionTypeFormatter;
+
+    public function __construct()
+    {
+        $this->reflectionTypeFormatter = (new ReflectionTypeFormatter())->withIsWrappingInClassName(false);
+    }
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionProperty); // Make phpstan happy
+
+        $str = sprintf(
+            '%s%s$%s',
+            Caster::makeNormalizedClassName($object->getDeclaringClass()),
+            ($object->isStatic() ? '::' : '->'),
+            $object->getName(),
+        );
+
+        if ($caster->isPrependingType() && $object->getType()) {
+            $str = $this->getReflectionTypeFormatter()->format($caster, $object->getType()) . ' ' . $str;
+        }
+
+        if ($object->hasDefaultValue()) {
+            $str .= ' = ' . $caster->cast($object->getDefaultValue());
+        }
+
+        if ($this->isWrappingInClassName()) {
+            $str = sprintf(
+                '%s (%s)',
+                Caster::makeNormalizedClassName(new ReflectionClass($object)),
+                $str,
+            );
+        }
+
+        return $str;
+    }
+
+    public function getReflectionTypeFormatter(): ReflectionTypeFormatter
+    {
+        return $this->reflectionTypeFormatter;
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionProperty);
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withReflectionTypeFormatter(ReflectionTypeFormatter $reflectionTypeFormatter): self
+    {
+        $clone = clone $this;
+        $clone->reflectionTypeFormatter = $reflectionTypeFormatter;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+}

--- a/src/Formatter/Object_/ReflectionTypeFormatter.php
+++ b/src/Formatter/Object_/ReflectionTypeFormatter.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Abstraction\Formatter\AbstractObjectFormatter;
+use Eboreum\Caster\Contract\CasterInterface;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+use function array_walk;
+use function assert;
+use function class_exists;
+use function enum_exists;
+use function explode;
+use function implode;
+use function interface_exists;
+use function ltrim;
+use function trait_exists;
+
+/**
+ * @inheritDoc
+ *
+ * Formats instances of \ReflectionType.
+ *
+ * @see https://www.php.net/manual/en/class.reflectiontype.php
+ */
+class ReflectionTypeFormatter extends AbstractObjectFormatter
+{
+    public static function isClassishReference(string $str): bool
+    {
+        return (
+            class_exists($str)
+            || enum_exists($str)
+            || interface_exists($str)
+            || trait_exists($str)
+        );
+    }
+
+    protected bool $isWrappingInClassName = true;
+
+    public function format(CasterInterface $caster, object $object): ?string
+    {
+        if (false === $this->isHandling($object)) {
+            return null; // Pass on
+        }
+
+        assert($object instanceof ReflectionType); // Make phpstan happy
+
+        if ($object instanceof ReflectionNamedType) {
+            $typeStrWithoutNullable = ltrim((string) $object, '?');
+
+            if (self::isClassishReference($typeStrWithoutNullable)) {
+                return ($object->allowsNull() ? '?' : '') . '\\' . $typeStrWithoutNullable;
+            }
+
+            return (string) $object;
+        }
+
+        if ($object instanceof ReflectionIntersectionType || $object instanceof ReflectionUnionType) {
+            $separator = ($object instanceof ReflectionIntersectionType ? '&' : '|');
+            $parts = explode($separator, (string) $object);
+
+            array_walk($parts, static function (string &$v): void {
+                if (self::isClassishReference($v)) {
+                    $v = '\\' . $v;
+                }
+            });
+
+            return implode($separator, $parts);
+        }
+
+        return (string) $object; // Fallback
+    }
+
+    public function isHandling(object $object): bool
+    {
+        return ($object instanceof ReflectionType);
+    }
+
+    public function isWrappingInClassName(): bool
+    {
+        return $this->isWrappingInClassName;
+    }
+
+    /**
+     * Returns a clone.
+     */
+    public function withIsWrappingInClassName(bool $isWrappingInClassName): self
+    {
+        $clone = clone $this;
+        $clone->isWrappingInClassName = $isWrappingInClassName;
+
+        return $clone;
+    }
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWitNamedArguments/Attributef982a9e0c18911edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWitNamedArguments/Attributef982a9e0c18911edafa10242ac120002.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWitNamedArguments;
+
+use Attribute;
+
+#[Attribute]
+class Attributef982a9e0c18911edafa10242ac120002
+{
+    public readonly string $foo;
+
+    public readonly string $bar;
+
+    public function __construct(string $foo, string $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWitNamedArguments/Classf982a9e0c18911edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWitNamedArguments/Classf982a9e0c18911edafa10242ac120002.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWitNamedArguments;
+
+#[Attributef982a9e0c18911edafa10242ac120002(foo: 'lorem', bar: 'ipsum')]
+class Classf982a9e0c18911edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments/Attributeda304392c18711edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments/Attributeda304392c18711edafa10242ac120002.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments;
+
+use Attribute;
+
+#[Attribute]
+class Attributeda304392c18711edafa10242ac120002
+{
+    public readonly string $foo;
+
+    public readonly string $bar;
+
+    public function __construct(string $foo, string $bar)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments/Classda304392c18711edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments/Classda304392c18711edafa10242ac120002.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments;
+
+#[Attributeda304392c18711edafa10242ac120002('lorem', 'ipsum')]
+class Classda304392c18711edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithoutArguments/Attributeda304090c18711edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithoutArguments/Attributeda304090c18711edafa10242ac120002.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithoutArguments;
+
+use Attribute;
+
+#[Attribute]
+class Attributeda304090c18711edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithoutArguments/Classda304090c18711edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithAReflectionAttributeWithoutArguments/Classda304090c18711edafa10242ac120002.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithoutArguments;
+
+#[Attributeda304090c18711edafa10242ac120002]
+class Classda304090c18711edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference/Trait06bcf914c18d11edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference/Trait06bcf914c18d11edafa10242ac120002.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference;
+
+trait Trait06bcf914c18d11edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference/Enum06bcf69ec18d11edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference/Enum06bcf69ec18d11edafa10242ac120002.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference;
+
+enum Enum06bcf69ec18d11edafa10242ac120002
+{
+}

--- a/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsAnInterfaceReference/Interface06bcfa5ec18d11edafa10242ac120002.php
+++ b/tests/resources/TestResource/Unit/Formatter/Object_/ReflectionAttributeFormatterTest/testFormatWorksWithReflectionClassArgumentWhenItContainsAnInterfaceReference/Interface06bcfa5ec18d11edafa10242ac120002.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsAnInterfaceReference;
+
+interface Interface06bcfa5ec18d11edafa10242ac120002
+{
+}

--- a/tests/tests/Test/Unit/AssertionTest.php
+++ b/tests/tests/Test/Unit/AssertionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster;
+
+use Eboreum\Caster\Assertion;
+use Eboreum\Caster\Exception\AssertionException;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class AssertionTest extends TestCase
+{
+    public function testAssertIsStringWorks(): void
+    {
+        Assertion::assertIsString('');
+        Assertion::assertIsString('foo');
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider dataProviderTestAssertIsStringThrowsExceptionWhenValueIsNotAString
+     */
+    public function testAssertIsStringThrowsExceptionWhenValueIsNotAString(
+        string $expected,
+        mixed $value,
+        ?string $message
+    ): void {
+        try {
+            Assertion::assertIsString($value, $message);
+        } catch (Exception $e) {
+            $currentException = $e;
+            $this->assertSame(AssertionException::class, $currentException::class);
+            $this->assertSame($expected, $currentException->getMessage());
+
+            $currentException = $currentException->getPrevious();
+            $this->assertTrue(null === $currentException);
+
+            return;
+        }
+
+        $this->fail('Exception was never thrown.');
+    }
+
+    /**
+     * @return array<array{string, mixed, string|null}>
+     */
+    public function dataProviderTestAssertIsStringThrowsExceptionWhenValueIsNotAString(): array
+    {
+        return [
+            [
+                'Expects argument $value = (int) 42 to be a string, but it is not',
+                42,
+                null,
+            ],
+            [
+                'Expects argument $value = (bool) true to be a string, but it is not: Lorem ipsum',
+                true,
+                'Lorem ipsum',
+            ],
+        ];
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionAttributeFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionAttributeFormatterTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatter;
+use PHPUnit\Framework\TestCase;
+use ReflectionAttribute;
+use ReflectionClass;
+use stdClass;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments\Attributeda304392c18711edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments\Classda304392c18711edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithoutArguments\Attributeda304090c18711edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWithoutArguments\Classda304090c18711edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWitNamedArguments\Attributef982a9e0c18911edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithAReflectionAttributeWitNamedArguments\Classf982a9e0c18911edafa10242ac120002;
+
+use function assert;
+use function implode;
+use function is_object;
+use function sprintf;
+
+class ReflectionAttributeFormatterTest extends TestCase
+{
+    public function testFormatWorksWithNonReflectionAttributes(): void
+    {
+        $caster = Caster::create();
+        $reflectionAttributeFormatter = new ReflectionAttributeFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionAttributeFormatter->isHandling($object));
+        $this->assertNull($reflectionAttributeFormatter->format($caster, $object));
+    }
+
+    public function testFormatWorksWithAReflectionAttributeWithoutArguments(): void
+    {
+        $caster = Caster::create();
+        $reflectionAttributeFormatter = new ReflectionAttributeFormatter();
+        $reflectionClass = new ReflectionClass(Classda304090c18711edafa10242ac120002::class);
+
+        /** @var ReflectionAttribute<Attributeda304090c18711edafa10242ac120002>|null $reflectionAttribute */
+        $reflectionAttribute = (
+            $reflectionClass->getAttributes(Attributeda304090c18711edafa10242ac120002::class)[0] ?? null
+        );
+
+        $this->assertIsObject($reflectionAttribute);
+        assert(is_object($reflectionAttribute));
+
+        $this->assertTrue($reflectionAttributeFormatter->isHandling($reflectionAttribute));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionAttribute (\\%s)',
+                Attributeda304090c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->format($caster, $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\%s',
+                Attributeda304090c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->withIsWrappingInClassName(false)->format($caster, $reflectionAttribute),
+        );
+    }
+
+    public function testFormatWorksWithAReflectionAttributeWithIntegerIndexedArguments(): void
+    {
+        $caster = Caster::create();
+        $reflectionAttributeFormatter = new ReflectionAttributeFormatter();
+        $reflectionClass = new ReflectionClass(Classda304392c18711edafa10242ac120002::class);
+
+        /** @var ReflectionAttribute<Attributeda304392c18711edafa10242ac120002>|null $reflectionAttribute */
+        $reflectionAttribute = (
+            $reflectionClass->getAttributes(Attributeda304392c18711edafa10242ac120002::class)[0] ?? null
+        );
+
+        $this->assertIsObject($reflectionAttribute);
+        assert(is_object($reflectionAttribute));
+
+        $this->assertTrue($reflectionAttributeFormatter->isHandling($reflectionAttribute));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionAttribute (\\%s (0: "lorem", 1: "ipsum"))',
+                Attributeda304392c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->format($caster, $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                implode('', [
+                    '\\ReflectionAttribute ((attribute) \\%s (0: (string(5)) "lorem", 1: (string(5))',
+                    ' "ipsum"))',
+                ]),
+                Attributeda304392c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->format($caster->withIsPrependingType(true), $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\%s (0: "lorem", 1: "ipsum")',
+                Attributeda304392c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->withIsWrappingInClassName(false)->format($caster, $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '(attribute) \\%s (0: (string(5)) "lorem", 1: (string(5)) "ipsum")',
+                Attributeda304392c18711edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter
+                ->withIsWrappingInClassName(false)
+                ->format($caster->withIsPrependingType(true), $reflectionAttribute),
+        );
+    }
+
+    public function testFormatWorksWithAReflectionAttributeWitNamedArguments(): void
+    {
+        $caster = Caster::create();
+        $reflectionAttributeFormatter = new ReflectionAttributeFormatter();
+        $reflectionClass = new ReflectionClass(Classf982a9e0c18911edafa10242ac120002::class);
+
+        /** @var ReflectionAttribute<Attributef982a9e0c18911edafa10242ac120002>|null $reflectionAttribute */
+        $reflectionAttribute = (
+            $reflectionClass->getAttributes(Attributef982a9e0c18911edafa10242ac120002::class)[0] ?? null
+        );
+
+        $this->assertIsObject($reflectionAttribute);
+        assert(is_object($reflectionAttribute));
+
+        $this->assertTrue($reflectionAttributeFormatter->isHandling($reflectionAttribute));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionAttribute (\\%s (foo: "lorem", bar: "ipsum"))',
+                Attributef982a9e0c18911edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->format($caster, $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionAttribute ((attribute) \\%s (foo: (string(5)) "lorem", bar: (string(5)) "ipsum"))',
+                Attributef982a9e0c18911edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->format($caster->withIsPrependingType(true), $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\%s (foo: "lorem", bar: "ipsum")',
+                Attributef982a9e0c18911edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter->withIsWrappingInClassName(false)->format($caster, $reflectionAttribute),
+        );
+        $this->assertSame(
+            sprintf(
+                '(attribute) \\%s (foo: (string(5)) "lorem", bar: (string(5)) "ipsum")',
+                Attributef982a9e0c18911edafa10242ac120002::class,
+            ),
+            $reflectionAttributeFormatter
+                ->withIsWrappingInClassName(false)
+                ->format($caster->withIsPrependingType(true), $reflectionAttribute),
+        );
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionAttributeFormatterA = new ReflectionAttributeFormatter();
+        $reflectionAttributeFormatterB = $reflectionAttributeFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionAttributeFormatterA, $reflectionAttributeFormatterB);
+        $this->assertTrue($reflectionAttributeFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionAttributeFormatterB->isWrappingInClassName());
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionClassFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionClassFormatterTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Formatter\Object_\ReflectionClassFormatter;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference\Enum06bcf69ec18d11edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsAnInterfaceReference\Interface06bcfa5ec18d11edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference\Trait06bcf914c18d11edafa10242ac120002;
+
+use function sprintf;
+
+class ReflectionClassFormatterTest extends TestCase
+{
+    public function testFormatWorksWithNonReflectionClass(): void
+    {
+        $caster = Caster::create();
+        $reflectionClassFormatter = new ReflectionClassFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionClassFormatter->isHandling($object));
+        $this->assertNull($reflectionClassFormatter->format($caster, $object));
+    }
+
+    public function testFormatWorksWithReflectionClassArgumentWhenItContainsAClassReference(): void
+    {
+        $caster = Caster::create();
+        $reflectionClassFormatter = new ReflectionClassFormatter();
+        $reflectionClass = new ReflectionClass(self::class);
+
+        $this->assertTrue($reflectionClassFormatter->isHandling($reflectionClass));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass (\\%s)',
+                self::class,
+            ),
+            $reflectionClassFormatter->format($caster, $reflectionClass)
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass ((class) \\%s)',
+                self::class,
+            ),
+            $reflectionClassFormatter->format($caster->withIsPrependingType(true), $reflectionClass),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\%s',
+                self::class,
+            ),
+            $reflectionClassFormatter->withIsWrappingInClassName(false)->format($caster, $reflectionClass),
+        );
+        $this->assertSame(
+            sprintf(
+                '(class) \\%s',
+                self::class,
+            ),
+            $reflectionClassFormatter
+                ->withIsWrappingInClassName(false)
+                ->format(
+                    $caster->withIsPrependingType(true),
+                    $reflectionClass,
+                ),
+        );
+    }
+
+    public function testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference(): void
+    {
+        $caster = Caster::create();
+        $reflectionClassFormatter = new ReflectionClassFormatter();
+        $reflectionClass = new ReflectionClass(Enum06bcf69ec18d11edafa10242ac120002::class);
+
+        $this->assertTrue($reflectionClass->isEnum());
+        $this->assertTrue($reflectionClassFormatter->isHandling($reflectionClass));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass (\\%s)',
+                Enum06bcf69ec18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster, $reflectionClass),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass ((enum) \\%s)',
+                Enum06bcf69ec18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster->withIsPrependingType(true), $reflectionClass),
+        );
+    }
+
+    public function testFormatWorksWithReflectionClassArgumentWhenItContainsAnInterfaceReference(): void
+    {
+        $caster = Caster::create();
+        $reflectionClassFormatter = new ReflectionClassFormatter();
+        $reflectionClass = new ReflectionClass(Interface06bcfa5ec18d11edafa10242ac120002::class);
+
+        $this->assertTrue($reflectionClass->isInterface());
+        $this->assertTrue($reflectionClassFormatter->isHandling($reflectionClass));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass (\\%s)',
+                Interface06bcfa5ec18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster, $reflectionClass),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass ((interface) \\%s)',
+                Interface06bcfa5ec18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster->withIsPrependingType(true), $reflectionClass),
+        );
+    }
+
+    public function testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference(): void
+    {
+        $caster = Caster::create();
+        $reflectionClassFormatter = new ReflectionClassFormatter();
+        $reflectionClass = new ReflectionClass(Trait06bcf914c18d11edafa10242ac120002::class);
+
+        $this->assertTrue($reflectionClass->isTrait());
+        $this->assertTrue($reflectionClassFormatter->isHandling($reflectionClass));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass (\\%s)',
+                Trait06bcf914c18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster, $reflectionClass),
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionClass ((trait) \\%s)',
+                Trait06bcf914c18d11edafa10242ac120002::class,
+            ),
+            $reflectionClassFormatter->format($caster->withIsPrependingType(true), $reflectionClass),
+        );
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionClassFormatterA = new ReflectionClassFormatter();
+        $reflectionClassFormatterB = $reflectionClassFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionClassFormatterA, $reflectionClassFormatterB);
+        $this->assertTrue($reflectionClassFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionClassFormatterB->isWrappingInClassName());
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionMethodFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionMethodFormatterTest.php
@@ -1,0 +1,526 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Contract\CasterInterface;
+use Eboreum\Caster\EncryptedString;
+use Eboreum\Caster\Formatter\Object_\ReflectionMethodFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionParameterFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionTypeFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionObject;
+use stdClass;
+
+use function assert;
+use function basename;
+use function implode;
+use function is_string;
+use function preg_quote;
+use function sprintf;
+
+use const JSON_ERROR_DEPTH;
+
+class ReflectionMethodFormatterTest extends TestCase
+{
+    public function testFormatWorksWithNonReflectionMethod(): void
+    {
+        $caster = Caster::create();
+        $reflectionMethodFormatter = new ReflectionMethodFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionMethodFormatter->isHandling($object));
+        $this->assertNull($reflectionMethodFormatter->format($caster, $object));
+    }
+
+    public function testFormatWorksWithReflectionMethodWihtoutArguments(): void
+    {
+        $caster = Caster::create();
+        $reflectionMethodFormatter = new ReflectionMethodFormatter();
+        $reflectionMethod = new ReflectionMethod(self::class, __FUNCTION__);
+
+        $this->assertTrue($reflectionMethodFormatter->isHandling($reflectionMethod));
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionMethod (\\%s->%s(): void)',
+                self::class,
+                __FUNCTION__,
+            ),
+            $reflectionMethodFormatter->format($caster, $reflectionMethod)
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionMethod (\\%s->%s: void)',
+                self::class,
+                __FUNCTION__,
+            ),
+            $reflectionMethodFormatter->withIsRenderingParameters(false)->format($caster, $reflectionMethod)
+        );
+        $this->assertSame(
+            sprintf(
+                '\\ReflectionMethod (\\%s->%s())',
+                self::class,
+                __FUNCTION__,
+            ),
+            $reflectionMethodFormatter->withIsRenderingReturnType(false)->format($caster, $reflectionMethod)
+        );
+        $this->assertSame(
+            sprintf(
+                '\\%s->%s(): void',
+                self::class,
+                __FUNCTION__,
+            ),
+            $reflectionMethodFormatter->withIsWrappingInClassName(false)->format($caster, $reflectionMethod)
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderTestFormatWorksWithReflectionMethodWihtArguments
+     */
+    public function testFormatWorksWithReflectionMethodWihtArguments(
+        string $message,
+        string $expectedRegex,
+        Caster $caster,
+        ReflectionMethodFormatter $reflectionMethodFormatter,
+        ReflectionMethod $reflectionMethod,
+    ): void {
+        $this->assertTrue($reflectionMethodFormatter->isHandling($reflectionMethod), $message);
+
+        $formatted = $reflectionMethodFormatter->format($caster, $reflectionMethod);
+
+        $this->assertIsString($formatted);
+        assert(is_string($formatted));
+        $this->assertMatchesRegularExpression($expectedRegex, $formatted, $message);
+    }
+
+    /**
+     * @return array<array{string, string, Caster, ReflectionMethodFormatter, ReflectionMethod}>
+     */
+    public function dataProviderTestFormatWorksWithReflectionMethodWihtArguments(): array
+    {
+        return [
+            [
+                'A single argument. No default value. No return type.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo\)\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        // @phpstan-ignore-next-line
+                        public function lorem(int $foo) // phpcs:ignore
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument. No default value. "void" return type.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo\): void\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                '3 arguments. No default values. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo, string \$bar',
+                        ', bool \$baz\): void\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo, string $bar, bool $baz): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument with a primitive default value without type in front. "void" return type.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo = 42\): void\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo = 42): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument with a primitive default value with type in front. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo = \(int\) 42\):',
+                        ' void\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo = 42): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                '3 arguments with a primitive default values and with type in front. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo = \(int\) 42',
+                        ', string \$bar = \(string\(4\)\) "lala", bool \$baz = \(bool\) false\): void\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo = 42, string $bar = 'lala', bool $baz = false): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument with a global constant default value. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo =',
+                        ' \\\\JSON_ERROR_DEPTH\): void\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(int $foo = JSON_ERROR_DEPTH): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument with a self-constant default value. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(int \$foo = self::FOO\):',
+                        ' void\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public const FOO = 42;
+
+                        public function lorem(int $foo = self::FOO): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'A single argument with a parent-constant default value. "void" return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(\\\\%s@anonymous\/in\/.+\/%s:\d+->lorem\(string \$foo =',
+                        ' parent::ENCRYPTION_METHOD_DEFAULT\): void\)$/',
+                    ]),
+                    preg_quote(EncryptedString::class, '/'),
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class ('foo') extends EncryptedString
+                    {
+                        public function lorem(string $foo = parent::ENCRYPTION_METHOD_DEFAULT): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'No arguments. "int" return type.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(\): int\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(): int
+                        {
+                            return 42;
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'No arguments. Intersection return type.',
+                sprintf(
+                    implode('', [
+                        '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(\):',
+                        ' \\\\%s&\\\\%s\)$/',
+                    ]),
+                    preg_quote(basename(__FILE__), '/'),
+                    preg_quote(Caster::class, '/'),
+                    preg_quote(CasterInterface::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(): Caster&CasterInterface
+                        {
+                            return Caster::create();
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'No arguments. Union return type.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(\): float|int|string\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(): float|int|string
+                        {
+                            return 42;
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'No arguments. Nullable return type using question mark.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(\): \?int\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(): ?int
+                        {
+                            return 42;
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+            [
+                'No arguments. Nullable return type using "int|null". It gets converted to "?int" notation.',
+                sprintf(
+                    '/^\\\\ReflectionMethod \(class@anonymous\/in\/.+\/%s:\d+->lorem\(\): \?int\)$/',
+                    preg_quote(basename(__FILE__), '/'),
+                ),
+                Caster::create(),
+                new ReflectionMethodFormatter(),
+                (static function (): ReflectionMethod {
+                    $object = new class
+                    {
+                        public function lorem(): int|null
+                        {
+                            return 42;
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+
+                    return $reflectionObject->getMethod('lorem');
+                })(),
+            ],
+        ];
+    }
+
+    public function testWithIsRenderingParametersWorks(): void
+    {
+        $reflectionMethodFormatterA = new ReflectionMethodFormatter();
+        $reflectionMethodFormatterB = $reflectionMethodFormatterA->withIsRenderingParameters(false);
+
+        $this->assertNotSame($reflectionMethodFormatterA, $reflectionMethodFormatterB);
+        $this->assertTrue($reflectionMethodFormatterA->isRenderingParameters());
+        $this->assertFalse($reflectionMethodFormatterB->isRenderingParameters());
+    }
+
+    public function testWithIsRenderingReturnTypeWorks(): void
+    {
+        $reflectionMethodFormatterA = new ReflectionMethodFormatter();
+        $reflectionMethodFormatterB = $reflectionMethodFormatterA->withIsRenderingReturnType(false);
+
+        $this->assertNotSame($reflectionMethodFormatterA, $reflectionMethodFormatterB);
+        $this->assertTrue($reflectionMethodFormatterA->isRenderingReturnType());
+        $this->assertFalse($reflectionMethodFormatterB->isRenderingReturnType());
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionMethodFormatterA = new ReflectionMethodFormatter();
+        $reflectionMethodFormatterB = $reflectionMethodFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionMethodFormatterA, $reflectionMethodFormatterB);
+        $this->assertTrue($reflectionMethodFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionMethodFormatterB->isWrappingInClassName());
+    }
+
+    public function testWithReflectionParameterFormatterWorks(): void
+    {
+        $reflectionMethodFormatterA = new ReflectionMethodFormatter();
+        $reflectionParameterFormatterA = $reflectionMethodFormatterA->getReflectionParameterFormatter();
+        $reflectionParameterFormatterB = $this->mockReflectionParameterFormatter();
+        $reflectionMethodFormatterB = $reflectionMethodFormatterA
+            ->withReflectionParameterFormatter($reflectionParameterFormatterB);
+
+        $this->assertNotSame($reflectionMethodFormatterA, $reflectionMethodFormatterB);
+        $this->assertNotSame(
+            $reflectionMethodFormatterA->getReflectionParameterFormatter(),
+            $reflectionMethodFormatterB->getReflectionParameterFormatter(),
+        );
+        $this->assertSame(
+            $reflectionParameterFormatterA,
+            $reflectionMethodFormatterA->getReflectionParameterFormatter(),
+        );
+        $this->assertSame(
+            $reflectionParameterFormatterB,
+            $reflectionMethodFormatterB->getReflectionParameterFormatter(),
+        );
+    }
+
+    public function testWithReflectionTypeFormatterWorks(): void
+    {
+        $reflectionMethodFormatterA = new ReflectionMethodFormatter();
+        $reflectionTypeFormatterA = $reflectionMethodFormatterA->getReflectionTypeFormatter();
+        $reflectionTypeFormatterB = $this->mockReflectionTypeFormatter();
+        $reflectionMethodFormatterB = $reflectionMethodFormatterA
+            ->withReflectionTypeFormatter($reflectionTypeFormatterB);
+
+        $this->assertNotSame($reflectionMethodFormatterA, $reflectionMethodFormatterB);
+        $this->assertNotSame(
+            $reflectionMethodFormatterA->getReflectionTypeFormatter(),
+            $reflectionMethodFormatterB->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterA,
+            $reflectionMethodFormatterA->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterB,
+            $reflectionMethodFormatterB->getReflectionTypeFormatter(),
+        );
+    }
+
+    private function mockReflectionParameterFormatter(): ReflectionParameterFormatter&MockObject
+    {
+        return $this
+            ->getMockBuilder(ReflectionParameterFormatter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function mockReflectionTypeFormatter(): ReflectionTypeFormatter&MockObject
+    {
+        return $this
+            ->getMockBuilder(ReflectionTypeFormatter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionParameterFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionParameterFormatterTest.php
@@ -1,0 +1,509 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use DateTimeInterface;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\EncryptedString;
+use Eboreum\Caster\Exception\RuntimeException;
+use Eboreum\Caster\Formatter\Object_\ReflectionParameterFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionTypeFormatter;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionObject;
+use ReflectionParameter;
+use SplFileObject;
+use stdClass;
+
+use function assert;
+use function implode;
+use function is_object;
+use function is_string;
+use function sprintf;
+
+use const JSON_ERROR_NONE;
+
+class ReflectionParameterFormatterTest extends TestCase
+{
+    private const TEST_CONSTANT_2330CD52C3D911EDAFA10242AC120002 = 0;
+
+    public function testFormatWorksWithNonReflectionParameter(): void
+    {
+        $caster = Caster::create();
+        $reflectionParameterFormatter = new ReflectionParameterFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionParameterFormatter->isHandling($object));
+        $this->assertNull($reflectionParameterFormatter->format($caster, $object));
+    }
+
+    /**
+     * @dataProvider dataProviderTestFormatWorksForFunctionParameters
+     */
+    public function testFormatWorksForFunctionParameters(
+        string $message,
+        string $expectedRegex,
+        Caster $caster,
+        ReflectionParameterFormatter $reflectionParameterFormatter,
+        ReflectionParameter $reflectionParameter,
+    ): void {
+        $this->assertTrue($reflectionParameterFormatter->isHandling($reflectionParameter), $message);
+
+        $formatted = $reflectionParameterFormatter->format($caster, $reflectionParameter);
+
+        $this->assertIsString($formatted);
+        assert(is_string($formatted));
+        $this->assertMatchesRegularExpression($expectedRegex, $formatted, $message);
+    }
+
+    /**
+     * @return array<array{string, string, Caster, ReflectionParameterFormatter, ReflectionParameter}>
+     */
+    public function dataProviderTestFormatWorksForFunctionParameters(): array
+    {
+        return [
+            [
+                'Simple string parameter. No default value.',
+                '/^\\\\ReflectionParameter \(string \$haystack\)$/',
+                Caster::create(),
+                new ReflectionParameterFormatter(),
+                new ReflectionParameter('strpos', 'haystack'),
+            ],
+            [
+                'Simple int parameter with a default value being a literal.',
+                '/^\\\\ReflectionParameter \(int \$offset = 0\)$/',
+                Caster::create(),
+                new ReflectionParameterFormatter(),
+                new ReflectionParameter('strpos', 'offset'),
+            ],
+            [
+                'Simple int parameter with a default value being a literal and type being prepended.',
+                '/^\\\\ReflectionParameter \(int \$offset = \(int\) 0\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                new ReflectionParameter('strpos', 'offset'),
+            ],
+            [
+                'Simple int parameter with a default value being a global constant.',
+                '/^\\\\ReflectionParameter \(int \$foo = \\\\JSON_ERROR_NONE\)$/',
+                Caster::create(),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $function = static function (int $foo = JSON_ERROR_NONE): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    return $reflectionFunction->getParameters()[0];
+                })(),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestFormatWorksForMethodParameters
+     */
+    public function testFormatWorksForMethodParameters(
+        string $message,
+        string $expectedRegex,
+        Caster $caster,
+        ReflectionParameterFormatter $reflectionParameterFormatter,
+        ReflectionParameter $reflectionParameter,
+    ): void {
+        $this->assertTrue($reflectionParameterFormatter->isHandling($reflectionParameter), $message);
+
+        $formatted = $reflectionParameterFormatter->format($caster, $reflectionParameter);
+
+        $this->assertIsString($formatted);
+        assert(is_string($formatted));
+        $this->assertMatchesRegularExpression($expectedRegex, $formatted, $message);
+    }
+
+    /**
+     * @return array<array{string, string, Caster, ReflectionParameterFormatter, ReflectionParameter}>
+     */
+    public function dataProviderTestFormatWorksForMethodParameters(): array
+    {
+        return [
+            [
+                'Simple int parameter. No default value.',
+                '/^\\\\ReflectionParameter \(int \$flags\)$/',
+                Caster::create(),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $reflectionMethod = new ReflectionMethod(SplFileObject::class, 'setFlags');
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+            [
+                'Simple int parameter with a default value being a literal.',
+                '/^\\\\ReflectionParameter \(int \$length = 0\)$/',
+                Caster::create(),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $reflectionMethod = new ReflectionMethod(SplFileObject::class, 'fwrite');
+
+                    return $reflectionMethod->getParameters()[1];
+                })(),
+            ],
+            [
+                'Simple int parameter with a default value being a literal and type being prepended.',
+                '/^\\\\ReflectionParameter \(int \$length = \(int\) 0\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $reflectionMethod = new ReflectionMethod(SplFileObject::class, 'fwrite');
+
+                    return $reflectionMethod->getParameters()[1];
+                })(),
+            ],
+            [
+                'Simple int parameter with a default value being a global constant.',
+                '/^\\\\ReflectionParameter \(int \$foo = \\\\JSON_ERROR_NONE\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $reflectionMethod = new ReflectionMethod(
+                        self::class,
+                        'resourceMethodForTestFormatWorksForMethodParameters18525b4ec3d911edafa10242ac120002',
+                    );
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+            [
+                'Simple int parameter with a default value being a "self::" constant.',
+                '/^\\\\ReflectionParameter \(int \$foo = self::TEST_CONSTANT_2330CD52C3D911EDAFA10242AC120002\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $reflectionMethod = new ReflectionMethod(
+                        self::class,
+                        'resourceMethodForTestFormatWorksForMethodParameters2330cd52c3d911edafa10242ac120002',
+                    );
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+            [
+                'Simple string parameter with a default value being a "parent::" constant.',
+                '/^\\\\ReflectionParameter \(string \$foo = parent::ENCRYPTION_METHOD_DEFAULT\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $object = new class ('foo') extends EncryptedString
+                    {
+                        public function lorem(string $foo = parent::ENCRYPTION_METHOD_DEFAULT): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+                    $reflectionMethod = $reflectionObject->getMethod('lorem');
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+            [
+                'Simple string parameter with a default value being a class-reference constant.',
+                '/^\\\\ReflectionParameter \(string \$foo = \\\\DateTimeInterface::ATOM\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $object = new class ('foo') extends EncryptedString
+                    {
+                        public function lorem(string $foo = DateTimeInterface::ATOM): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+                    $reflectionMethod = $reflectionObject->getMethod('lorem');
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+            [
+                'Variadic string parameter without default value.',
+                '/^\\\\ReflectionParameter \(string \.\.\.\$foo\)$/',
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionParameterFormatter(),
+                (static function (): ReflectionParameter {
+                    $object = new class
+                    {
+                        public function lorem(string ...$foo): void
+                        {
+                        }
+                    };
+
+                    $reflectionObject = new ReflectionObject($object);
+                    $reflectionMethod = $reflectionObject->getMethod('lorem');
+
+                    return $reflectionMethod->getParameters()[0];
+                })(),
+            ],
+        ];
+    }
+
+    public function testFormatDefaultValueThrowsExceptionWhenNoDefaultValueIsAvailableOnFunction(): void
+    {
+        $caster = Caster::create();
+        $reflectionParameterFormatter = new ReflectionParameterFormatter();
+        $reflectionParameter = new ReflectionParameter('strpos', 'haystack');
+
+        try {
+            $reflectionParameterFormatter->formatDefaultValue($caster, $reflectionParameter);
+        } catch (Exception $e) {
+            $currentException = $e;
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                implode('', [
+                    'A problem was encountered for argument $reflectionParameter, having the parameter name',
+                    ' $haystack in function \\strpos',
+                ]),
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertIsObject($currentException);
+            assert(is_object($currentException));
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                'Parameter $haystack does not have a default value',
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertTrue(null === $currentException);
+
+            return;
+        }
+
+        $this->fail('Exception was never thrown.');
+    }
+
+    public function testFormatDefaultValueThrowsExceptionWhenNoDefaultValueIsAvailableOnNonStaticMethod(): void
+    {
+        $caster = Caster::create();
+        $reflectionParameterFormatter = new ReflectionParameterFormatter();
+        $reflectionMethod = new ReflectionMethod(SplFileObject::class, 'setFlags');
+        $reflectionParameter = $reflectionMethod->getParameters()[0] ?? null;
+
+        $this->assertIsObject($reflectionParameter);
+        assert(is_object($reflectionParameter));
+
+        try {
+            $reflectionParameterFormatter->formatDefaultValue($caster, $reflectionParameter);
+        } catch (Exception $e) {
+            $currentException = $e;
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                implode('', [
+                    'A problem was encountered for argument $reflectionParameter, having the parameter name',
+                    ' $flags in method \\SplFileObject->setFlags',
+                ]),
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertIsObject($currentException);
+            assert(is_object($currentException));
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                'Parameter $flags does not have a default value',
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertTrue(null === $currentException);
+
+            return;
+        }
+
+        $this->fail('Exception was never thrown.');
+    }
+
+    public function testFormatDefaultValueThrowsExceptionWhenNoDefaultValueIsAvailableOnStaticMethod(): void
+    {
+        $caster = Caster::create();
+        $reflectionParameterFormatter = new ReflectionParameterFormatter();
+        $reflectionMethod = new ReflectionMethod(EncryptedString::class, 'isEncryptionMethodValid');
+        $reflectionParameter = $reflectionMethod->getParameters()[0] ?? null;
+
+        $this->assertIsObject($reflectionParameter);
+        assert(is_object($reflectionParameter));
+
+        try {
+            $reflectionParameterFormatter->formatDefaultValue($caster, $reflectionParameter);
+        } catch (Exception $e) {
+            $currentException = $e;
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                sprintf(
+                    implode('', [
+                        'A problem was encountered for argument $reflectionParameter, having the parameter name',
+                        ' $encryptionMethod in method \\%s::isEncryptionMethodValid',
+                    ]),
+                    EncryptedString::class,
+                ),
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertIsObject($currentException);
+            assert(is_object($currentException));
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                'Parameter $encryptionMethod does not have a default value',
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertTrue(null === $currentException);
+
+            return;
+        }
+
+        $this->fail('Exception was never thrown.');
+    }
+
+    public function testFormatDefaultValueThrowsExceptionWhenResultingMatchIsInvalid(): void
+    {
+        $caster = Caster::create();
+        $reflectionParameterFormatter = new ReflectionParameterFormatter();
+        $reflectionParameter = $this->mockReflectionParameter();
+
+        $reflectionParameter
+            ->expects($this->once())
+            ->method('isDefaultValueAvailable')
+            ->with()
+            ->willReturn(true);
+
+        $reflectionParameter
+            ->expects($this->once())
+            ->method('isDefaultValueConstant')
+            ->with()
+            ->willReturn(true);
+
+        $reflectionParameter
+            ->expects($this->once())
+            ->method('getDefaultValueConstantName')
+            ->with()
+            ->willReturn('');
+
+        $reflectionParameter
+            ->expects($this->any())
+            ->method('getName')
+            ->with()
+            ->willReturn('foo');
+
+        try {
+            $reflectionParameterFormatter->formatDefaultValue($caster, $reflectionParameter);
+        } catch (Exception $e) {
+            $currentException = $e;
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertSame(
+                implode('', [
+                    'A problem was encountered for argument $reflectionParameter, having the parameter name $foo in',
+                    ' function \\',
+                ]),
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertIsObject($currentException);
+            assert(is_object($currentException));
+            $this->assertSame(RuntimeException::class, $currentException::class);
+            $this->assertMatchesRegularExpression(
+                implode('', [
+                    '/^Expects default value of parameter \$foo - a constant - to match regular expression \'.+\', but',
+                    ' it does not\. Found: \(string\(0\)\) ""$/',
+                ]),
+                $currentException->getMessage(),
+            );
+
+            $currentException = $currentException->getPrevious();
+            $this->assertTrue(null === $currentException);
+
+            return;
+        }
+
+        $this->fail('Exception was never thrown.');
+    }
+
+    public function testWithIsRenderingTypesWorks(): void
+    {
+        $reflectionParameterFormatterA = new ReflectionParameterFormatter();
+        $reflectionParameterFormatterB = $reflectionParameterFormatterA->withIsRenderingTypes(false);
+
+        $this->assertNotSame($reflectionParameterFormatterA, $reflectionParameterFormatterB);
+        $this->assertTrue($reflectionParameterFormatterA->isRenderingTypes());
+        $this->assertFalse($reflectionParameterFormatterB->isRenderingTypes());
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionParameterFormatterA = new ReflectionParameterFormatter();
+        $reflectionParameterFormatterB = $reflectionParameterFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionParameterFormatterA, $reflectionParameterFormatterB);
+        $this->assertTrue($reflectionParameterFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionParameterFormatterB->isWrappingInClassName());
+    }
+
+    public function testWithReflectionTypeFormatterWorks(): void
+    {
+        $reflectionParameterFormatterA = new ReflectionParameterFormatter();
+        $reflectionTypeFormatterA = $reflectionParameterFormatterA->getReflectionTypeFormatter();
+        $reflectionTypeFormatterB = $this->mockReflectionTypeFormatter();
+        $reflectionParameterFormatterB = $reflectionParameterFormatterA
+            ->withReflectionTypeFormatter($reflectionTypeFormatterB);
+
+        $this->assertNotSame($reflectionParameterFormatterA, $reflectionParameterFormatterB);
+        $this->assertNotSame(
+            $reflectionParameterFormatterA->getReflectionTypeFormatter(),
+            $reflectionParameterFormatterB->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterA,
+            $reflectionParameterFormatterA->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterB,
+            $reflectionParameterFormatterB->getReflectionTypeFormatter(),
+        );
+    }
+
+    private function resourceMethodForTestFormatWorksForMethodParameters18525b4ec3d911edafa10242ac120002( // @phpstan-ignore-line
+        int $foo = JSON_ERROR_NONE,
+    ): int {
+        return $foo;
+    }
+
+    private function resourceMethodForTestFormatWorksForMethodParameters2330cd52c3d911edafa10242ac120002( // @phpstan-ignore-line
+        int $foo = self::TEST_CONSTANT_2330CD52C3D911EDAFA10242AC120002,
+    ): int {
+        return $foo;
+    }
+
+    private function mockReflectionParameter(): ReflectionParameter&MockObject
+    {
+        return $this
+            ->getMockBuilder(ReflectionParameter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function mockReflectionTypeFormatter(): ReflectionTypeFormatter&MockObject
+    {
+        return $this
+            ->getMockBuilder(ReflectionTypeFormatter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionPropertyFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionPropertyFormatterTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Formatter\Object_\ReflectionPropertyFormatter;
+use Eboreum\Caster\Formatter\Object_\ReflectionTypeFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use stdClass;
+
+use function assert;
+use function is_string;
+use function preg_quote;
+use function sprintf;
+
+class ReflectionPropertyFormatterTest extends TestCase
+{
+    // @phpstan-ignore-next-line
+    private static $test1b5d80f8c3e711edafa10242ac120002; // phpcs:ignore
+
+    // @phpstan-ignore-next-line
+    private $testdb97c7b2c3e611edafa10242ac120002; // phpcs:ignore
+
+    public function testFormatWorksWithNonReflectionProperty(): void
+    {
+        $caster = Caster::create();
+        $reflectionPropertyFormatter = new ReflectionPropertyFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionPropertyFormatter->isHandling($object));
+        $this->assertNull($reflectionPropertyFormatter->format($caster, $object));
+    }
+
+    /**
+     * @dataProvider dataProviderTestFormatWorksWithReflectionProperty
+     */
+    public function testFormatWorksWithReflectionProperty(
+        string $message,
+        string $expectedRegex,
+        Caster $caster,
+        ReflectionPropertyFormatter $reflectionPropertyFormatter,
+        ReflectionProperty $reflectionProperty,
+    ): void {
+        $this->assertTrue($reflectionPropertyFormatter->isHandling($reflectionProperty), $message);
+
+        $formatted = $reflectionPropertyFormatter->format($caster, $reflectionProperty);
+
+        $this->assertIsString($formatted);
+        assert(is_string($formatted));
+        $this->assertMatchesRegularExpression($expectedRegex, $formatted, $message);
+    }
+
+    /**
+     * @return array<array{string, string, Caster, ReflectionPropertyFormatter, ReflectionProperty}>
+     */
+    public function dataProviderTestFormatWorksWithReflectionProperty(): array
+    {
+        return [
+            [
+                'A static property with no type and a no default value. Type not prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(\\\\%s::\$test1b5d80f8c3e711edafa10242ac120002 = null\)$/',
+                    preg_quote(self::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(self::class, 'test1b5d80f8c3e711edafa10242ac120002'),
+            ],
+            [
+                'A non-static property with type bool and a default value. Type not prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(\\\\%1$s::\$instance = null\)$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(Caster::class, 'instance'),
+            ],
+            [
+                'A non-static property with type bool and a default value. Type is prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(\\?\\\\%s \\\\%1$s::\$instance = \(null\) null\)$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(Caster::class, 'instance'),
+            ],
+            [
+                'A non-static property with no type and a no default value. Type not prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(\\\\%s->\$testdb97c7b2c3e611edafa10242ac120002 = null\)$/',
+                    preg_quote(self::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(self::class, 'testdb97c7b2c3e611edafa10242ac120002'),
+            ],
+            [
+                'A non-static property with type bool and a default value. Type not prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(\\\\%s->\$isPrependingType = false\)$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(Caster::class, 'isPrependingType'),
+            ],
+            [
+                'A non-static property with type bool and a default value. Type is prepended.',
+                sprintf(
+                    '/^\\\\ReflectionProperty \(bool \\\\%s->\$isPrependingType = \(bool\) false\)$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create()->withIsPrependingType(true),
+                new ReflectionPropertyFormatter(),
+                new ReflectionProperty(Caster::class, 'isPrependingType'),
+            ],
+        ];
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionPropertyFormatterA = new ReflectionPropertyFormatter();
+        $reflectionPropertyFormatterB = $reflectionPropertyFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionPropertyFormatterA, $reflectionPropertyFormatterB);
+        $this->assertTrue($reflectionPropertyFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionPropertyFormatterB->isWrappingInClassName());
+    }
+
+    public function testWithReflectionTypeFormatterWorks(): void
+    {
+        $reflectionPropertyFormatterA = new ReflectionPropertyFormatter();
+        $reflectionTypeFormatterA = $reflectionPropertyFormatterA->getReflectionTypeFormatter();
+        $reflectionTypeFormatterB = $this->mockReflectionTypeFormatter();
+        $reflectionPropertyFormatterB = $reflectionPropertyFormatterA
+            ->withReflectionTypeFormatter($reflectionTypeFormatterB);
+
+        $this->assertNotSame($reflectionPropertyFormatterA, $reflectionPropertyFormatterB);
+        $this->assertNotSame(
+            $reflectionPropertyFormatterA->getReflectionTypeFormatter(),
+            $reflectionPropertyFormatterB->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterA,
+            $reflectionPropertyFormatterA->getReflectionTypeFormatter(),
+        );
+        $this->assertSame(
+            $reflectionTypeFormatterB,
+            $reflectionPropertyFormatterB->getReflectionTypeFormatter(),
+        );
+    }
+
+    private function mockReflectionTypeFormatter(): ReflectionTypeFormatter&MockObject
+    {
+        return $this
+            ->getMockBuilder(ReflectionTypeFormatter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/tests/Test/Unit/Formatter/Object_/ReflectionTypeFormatterTest.php
+++ b/tests/tests/Test/Unit/Formatter/Object_/ReflectionTypeFormatterTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Unit\Eboreum\Caster\Formatter\Object_;
+
+use DateTimeInterface;
+use Eboreum\Caster\Caster;
+use Eboreum\Caster\Formatter\Object_\ReflectionTypeFormatter;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionParameter;
+use ReflectionProperty;
+use ReflectionType;
+use SplFileInfo;
+use SplFileObject;
+use stdClass;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsAnEnumReference\Enum06bcf69ec18d11edafa10242ac120002;
+use TestResource\Unit\Eboreum\Caster\Formatter\Object_\ReflectionAttributeFormatterTest\testFormatWorksWithReflectionClassArgumentWhenItContainsATraitReference\Trait06bcf914c18d11edafa10242ac120002;
+
+use function assert;
+use function is_object;
+use function is_string;
+use function preg_quote;
+use function sprintf;
+
+class ReflectionTypeFormatterTest extends TestCase
+{
+    public function testFormatWorksWithNonReflectionType(): void
+    {
+        $caster = Caster::create();
+        $reflectionTypeFormatter = new ReflectionTypeFormatter();
+        $object = new stdClass();
+
+        $this->assertFalse($reflectionTypeFormatter->isHandling($object));
+        $this->assertNull($reflectionTypeFormatter->format($caster, $object));
+    }
+
+    /**
+     * @dataProvider dataProviderTestFormatWorksWithReflectionType
+     */
+    public function testFormatWorksWithReflectionType(
+        string $message,
+        string $expectedRegex,
+        Caster $caster,
+        ReflectionTypeFormatter $reflectionTypeFormatter,
+        ReflectionType $reflectionType,
+    ): void {
+        $this->assertTrue($reflectionTypeFormatter->isHandling($reflectionType), $message);
+
+        $formatted = $reflectionTypeFormatter->format($caster, $reflectionType);
+
+        $this->assertIsString($formatted);
+        assert(is_string($formatted));
+        $this->assertMatchesRegularExpression($expectedRegex, $formatted, $message);
+    }
+
+    /**
+     * @return array<array{string, string, Caster, ReflectionTypeFormatter, ReflectionType}>
+     */
+    public function dataProviderTestFormatWorksWithReflectionType(): array
+    {
+        return [
+            [
+                'A primitive type, "int".',
+                '/^int$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $reflectionParameter = new ReflectionParameter('strpos', 'offset');
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A primitive type, "string".',
+                '/^string$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $reflectionParameter = new ReflectionParameter('strpos', 'haystack');
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A nullable – using question mark syntax – primitive type.',
+                '/^\?int$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $function = static function (?int $foo): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    /** @var ReflectionParameter|null $reflectionParameter */
+                    $reflectionParameter = $reflectionFunction->getParameters()[0] ?? null;
+
+                    $this->assertIsObject($reflectionParameter);
+                    assert(is_object($reflectionParameter));
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A nullable – using "|null" syntax – primitive type. It gets converted to question mark syntax.',
+                '/^\?int$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $function = static function (int|null $foo): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    /** @var ReflectionParameter|null $reflectionParameter */
+                    $reflectionParameter = $reflectionFunction->getParameters()[0] ?? null;
+
+                    $this->assertIsObject($reflectionParameter);
+                    assert(is_object($reflectionParameter));
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A nullable – using question mark syntax – class reference.',
+                sprintf(
+                    '/^\?\\\\%s$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $reflectionProperty = new ReflectionProperty(Caster::class, 'instance');
+
+                    $reflectionType = $reflectionProperty->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A nullable – using "|null" syntax – class reference. It gets converted to question mark syntax.',
+                sprintf(
+                    '/^\?\\\\%s$/',
+                    preg_quote(Caster::class, '/'),
+                ),
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $function = static function (Caster|null $caster): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    /** @var ReflectionParameter|null $reflectionParameter */
+                    $reflectionParameter = $reflectionFunction->getParameters()[0] ?? null;
+
+                    $this->assertIsObject($reflectionParameter);
+                    assert(is_object($reflectionParameter));
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'An intersection type.',
+                '/^\\\\SplFileObject&\\\\SplFileInfo$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $function = static function (SplFileObject&SplFileInfo $foo): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    /** @var ReflectionParameter|null $reflectionParameter */
+                    $reflectionParameter = $reflectionFunction->getParameters()[0] ?? null;
+
+                    $this->assertIsObject($reflectionParameter);
+                    assert(is_object($reflectionParameter));
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'A union type.',
+                '/^\\\\SplFileObject\|int$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (function (): ReflectionType {
+                    $function = static function (SplFileObject|int $foo): void {
+                    };
+                    $reflectionFunction = new ReflectionFunction($function);
+
+                    /** @var ReflectionParameter|null $reflectionParameter */
+                    $reflectionParameter = $reflectionFunction->getParameters()[0] ?? null;
+
+                    $this->assertIsObject($reflectionParameter);
+                    assert(is_object($reflectionParameter));
+
+                    $reflectionType = $reflectionParameter->getType();
+
+                    $this->assertIsObject($reflectionType);
+                    assert(is_object($reflectionType));
+
+                    return $reflectionType;
+                })(),
+            ],
+            [
+                'The bottom fallback.',
+                '/^foo$/',
+                Caster::create(),
+                new ReflectionTypeFormatter(),
+                (static function (): ReflectionType {
+                    return new class extends ReflectionType
+                    {
+                        public function __toString(): string
+                        {
+                            return 'foo';
+                        }
+
+                        public function allowsNull(): bool
+                        {
+                            return true;
+                        }
+                    };
+                })(),
+            ],
+        ];
+    }
+
+    public function testIsClassishReferenceWorks(): void
+    {
+        $this->assertFalse(ReflectionTypeFormatter::isClassishReference(''));
+        $this->assertFalse(ReflectionTypeFormatter::isClassishReference('int'));
+        $this->assertFalse(ReflectionTypeFormatter::isClassishReference('string'));
+        $this->assertTrue(ReflectionTypeFormatter::isClassishReference('SplFileObject'));
+        $this->assertTrue(ReflectionTypeFormatter::isClassishReference(ReflectionTypeFormatter::class));
+        $this->assertTrue(ReflectionTypeFormatter::isClassishReference(Enum06bcf69ec18d11edafa10242ac120002::class));
+        $this->assertTrue(ReflectionTypeFormatter::isClassishReference(DateTimeInterface::class));
+        $this->assertTrue(ReflectionTypeFormatter::isClassishReference(Trait06bcf914c18d11edafa10242ac120002::class));
+    }
+
+    public function testWithIsWrappingInClassNameWorks(): void
+    {
+        $reflectionTypeFormatterA = new ReflectionTypeFormatter();
+        $reflectionTypeFormatterB = $reflectionTypeFormatterA->withIsWrappingInClassName(false);
+
+        $this->assertNotSame($reflectionTypeFormatterA, $reflectionTypeFormatterB);
+        $this->assertTrue($reflectionTypeFormatterA->isWrappingInClassName());
+        $this->assertFalse($reflectionTypeFormatterB->isWrappingInClassName());
+    }
+}


### PR DESCRIPTION
@see https://www.php.net/manual/en/book.reflection.php

Also added some convenience methods to the Caster class, utilizing said Reflection API formatters. These methods do NOT exist in CasterInterface, as this would have been a breaking change.

Additionally, a bit of phpcs and phpstan cleanup was performed.